### PR TITLE
Adds a canonical URL

### DIFF
--- a/conf.py.in
+++ b/conf.py.in
@@ -83,7 +83,8 @@ html_theme_options = {
   'display_version': True,
   'prev_next_buttons_location': None,
   'titles_only': True,
-  'versioning': True
+  'versioning': True,
+  'canonical_url': 'https://qgis.org/pyqgis/latest',
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
Adds Canonical URL to help SEOs find the most relevant pyqgis API version instead of outdated ones