### PR TITLE
Fix QgsVectorLayer.deleteSelectedFeatures docs

### DIFF
--- a/master/core/QgsVectorLayer.html
+++ b/master/core/QgsVectorLayer.html
@@ -4860,16 +4860,16 @@ changes can be discarded by calling <a class="reference internal" href="#qgis.co
 <dl class="field-list simple">
 <dt class="field-odd">Parameters</dt>
 <dd class="field-odd"><ul class="simple">
-<li><p><strong>deletedCount</strong> – The number of successfully deleted features</p></li>
 <li><p><strong>context</strong> (<em>QgsVectorLayer.DeleteContext = None</em>) – The chain of features who will be deleted for feedback and to avoid endless recursions</p></li>
 </ul>
 </dd>
 <dt class="field-even">Return type</dt>
 <dd class="field-even"><p>Tuple[bool, int]</p>
 </dd>
-<dt class="field-odd">Returns</dt>
-<dd class="field-odd"><p><code class="docutils literal notranslate"><span class="pre">True</span></code> in case of success and <code class="docutils literal notranslate"><span class="pre">False</span></code> otherwise</p>
-</dd>
+<dt class="field-odd">Returns</dt><p><ul class="simple">
+<li><p><code class="docutils literal notranslate"><span class="pre">True</span></code> in case of success and <code class="docutils literal notranslate"><span class="pre">False</span></code> otherwise</p></li>
+<li><p>The number of successfully deleted features</p></li>
+</ul>
 </dl>
 </dd></dl>
 


### PR DESCRIPTION
It mentions `deletedCount` is a parameter, but it's not. As it returns a `tuple(bool, int)` it would make all the sense for this value to be the `int` in the tuple.