### PR TITLE
Use a wider width for pyQGIS documentation for text and tables

### DIFF
--- a/_templates/theme_overrides.css
+++ b/_templates/theme_overrides.css
@@ -1,0 +1,25 @@
+/* Import rtd theme */
+@import url(theme.css);
+
+/* Customize for QGIS PYQGIS Documentation*/
+
+/* Widen space for the documentation content*/
+.wy-nav-content {
+	max-width: 1260px;
+}
+
+
+/* override table width restrictions 
+from https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: auto !important;
+   }
+}

--- a/conf.py.in
+++ b/conf.py.in
@@ -86,6 +86,12 @@ html_theme_options = {
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 
+# A list of CSS files. The entry must be a filename string or a tuple containing
+# the filename string and the attributes dictionary. The filename must be relative
+# to the html_static_path, or a full URI with scheme like https://example.org/style.css.
+# The attributes is used for attributes of <link> tag. It defaults to an empty list.
+html_css_files = ['./_templates/theme_overrides.css']
+
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 html_title = ""


### PR DESCRIPTION
An attempt to fix #36 (I simply pick and adapt what we use in the user docs repo - a larger width for docs, and allow table overflow). 
@3nids, I have no trust on how I set the [html_css_files](https://docs.readthedocs.io/en/stable/guides/adding-custom-css.html#adding-custom-css-or-javascript-to-sphinx-documentation), as I'm unsure of where the html_static_path resides. And I [fail to trigger a local build](https://github.com/DelazJ/pyqgis/actions?query=event%3Aworkflow_dispatch+) before opening a PR.
I also notice that the issue with table width may be also observed in another manner, e.g. https://qgis.org/pyqgis/master/gui/QgsRubberBand.html where table expand over the allowed width for the docs (instead of being cropped as in #36)

![image](https://user-images.githubusercontent.com/7983394/168064161-69fadd50-e1b8-43f9-95b9-136ddae1d3e7.png)
