### PR TITLE
Adding entries to directly reach repositories and website

### DIFF
--- a/_templates/versions.html
+++ b/_templates/versions.html
@@ -46,6 +46,18 @@
           </dd>
       </dl>
       {% endif %}
+      <dl>
+        <dt>{{ _('On QGIS Project') }}</dt>
+          <dd>
+            <a href="https://qgis.org" target="_blank" rel="noopener noreferrer">{{ _('Project Home') }}</a>
+          </dd>
+          <dd>
+            <a href="https://github.com/qgis/pyqgis/tree/master" target="_blank" rel="noopener noreferrer">{{ _('Repository') }}</a>
+          </dd>
+          <dd>
+            <a href="https://github.com/qgis/QGIS/tree/{{ current_version }}" target="_blank" rel="noopener noreferrer">{{ _('Source Code') }}</a>
+          </dd>
+      </dl>
       <hr/>
     </div>
   </div>


### PR DESCRIPTION
The idea is to have ways to directly access source code repo and this one, to either report or fix issues. It reaches only the main page of the repos, not the one of the class you might be reading.
Suggestions for better labels are welcome