### PR TITLE
add matomo script to static resources

### DIFF
--- a/_static/css/js/matomo.js
+++ b/_static/css/js/matomo.js
@@ -1,0 +1,12 @@
+var _paq = window._paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(["disableCookies"]);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="//matomo.qgis.org/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '1']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();


### PR DESCRIPTION
I've added in the resources, but I'm not sure how to plug now this script into the template
https://github.com/qgis/pyqgis/blob/master/scripts/build-docs.sh#L57C42-L57C42